### PR TITLE
Parameter name "in" appears to be reserved

### DIFF
--- a/semaphore.cfc
+++ b/semaphore.cfc
@@ -122,12 +122,12 @@ component {
 		return left(crc, 6);
 	}
 
-	private string function structToDeterministicString( required struct in ){
-		var keys = structKeyArray( arguments.in );
+	private string function structToDeterministicString( required struct input ){
+		var keys = structKeyArray( arguments.input );
 		var data = [];
 		arraySort( keys, 'text' );
 		for ( var propName in keys ){
-			data.append({ '#propName#': arguments.in[propName] });
+			data.append({ '#propName#': arguments.input[propName] });
 		}
 		return serializeJson( data );
 	}


### PR DESCRIPTION
ColdFusion 2016 throws a compiler error if "in" is used as a function parameter name. It appears to be reserved.